### PR TITLE
we need to send tracking event multiple times in order to view it in our funnels

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tiny-experiment",
   "version": "1.1.8",
   "description": "Lightweight javascript module to run AB tests",
-  "main": "./distribution/index.js",
+  "main": "./source/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "babel source --presets babel-preset-es2015 --out-dir distribution",

--- a/source/tinyExperiment.js
+++ b/source/tinyExperiment.js
@@ -11,6 +11,7 @@ export default class TinyExperiment {
     this.variantId = undefined;
 
     this._cookies = new TinyExperimentCookieInterface();
+    this._rerun = args.rerun || false;
     this._cached = args.cached || false;
     this._cachePeriod = args.cachePeriod || 7;
     this._variantHandlers = {};
@@ -101,7 +102,16 @@ export default class TinyExperiment {
 
     if (!this._tracked) {
       this._executeExperiment.bind(this)();
-    } else {
+    }
+    else if (this._rerun) {
+      this._completionHandler.call(this, {
+        experimentName: this.experimentName,
+        variantId: this.variantId,
+        variantName: this.variantName,
+        variantNames: this.variantNames
+      });
+    }
+    else {
       this._cancelExperiment();
     }
 


### PR DESCRIPTION
is the title clear? we want to cache the experiment so that the user does/doesn't see the experiment consistently. but every time we check the variant we want to send the tracking event so that it shows up nicely in mixpanel (via segment).